### PR TITLE
Add an object-fit trailer iframe for YouTube videos

### DIFF
--- a/de-de/index.html
+++ b/de-de/index.html
@@ -109,6 +109,14 @@
 
         </div>
 
+        <!--==================== TRAILER ====================-->
+        <section class="section trailer" id="trailer">
+            <div class="trailer__container container grid">
+                <iframe src="https://www.youtube.com/embed/Y_nIJRl7kU8?si=Mm6gDvk987BAOwQO" title="YouTube video player" frameborder="0" style="aspect-ratio: 16/9; width: 100%; height: 100%;"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+            </div>
+        </section>
+
         <!--==================== ABOUT ====================-->
         <section class="section about" id="about">
             <div class="about__container container grid">

--- a/index.html
+++ b/index.html
@@ -106,6 +106,15 @@
 
         </div>
 
+
+        <!--==================== TRAILER ====================-->
+        <section class="section trailer" id="trailer">
+            <div class="trailer__container container grid">
+                <iframe src="https://www.youtube.com/embed/Y_nIJRl7kU8?si=Mm6gDvk987BAOwQO" title="YouTube video player" frameborder="0" style="aspect-ratio: 16/9; width: 100%; height: 100%;"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+            </div>
+        </section>
+
         <!--==================== ABOUT ====================-->
         <section class="section about" id="about">
             <div class="about__container container grid">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,10 +6,10 @@
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <url>
     <loc>https://www.the-first-explorers.com/</loc>
-    <lastmod>2022-12-17T16:00:00+00:00</lastmod>
+    <lastmod>2023-10-18T21:00:00+00:00</lastmod>
   </url>
   <url>
     <loc>https://www.the-first-explorers.com/de-de</loc>
-    <lastmod>2022-12-17T16:00:00+00:00</lastmod>
+    <lastmod>2023-10-18T21:00:00+00:00</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
Make sure to change the URL to the correct YouTube link, the image should always scale to a 16/9 ratio full-width size (the size it's allowed to take up by it's container).

The `allow` tags are generated by YouTube as a standard thing, feel free to change these to your current preferences. 👍 